### PR TITLE
.NET Core support

### DIFF
--- a/LibOrbisPkg.Core/LibOrbisPkg.Core.csproj
+++ b/LibOrbisPkg.Core/LibOrbisPkg.Core.csproj
@@ -1,0 +1,63 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>LibOrbisPkg</RootNamespace>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>false</Optimize>
+    <DefineConstants>TRACE;DEBUG;CORE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <Optimize>true</Optimize>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>TRACE;CORE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\LibOrbisPkg\GP4\Gp4Project.cs" Link="GP4\Gp4Project.cs" />
+    <Compile Include="..\LibOrbisPkg\PFS\FlatPathTable.cs" Link="PFS\FlatPathTable.cs" />
+    <Compile Include="..\LibOrbisPkg\PFS\FSTree.cs" Link="PFS\FSTree.cs" />
+    <Compile Include="..\LibOrbisPkg\PFS\PFSBuilder.cs" Link="PFS\PFSBuilder.cs" />
+    <Compile Include="..\LibOrbisPkg\PFS\PFSCWriter.cs" Link="PFS\PFSCWriter.cs" />
+    <Compile Include="..\LibOrbisPkg\PFS\PfsProperties.cs" Link="PFS\PfsProperties.cs" />
+    <Compile Include="..\LibOrbisPkg\PFS\PfsStructs.cs" Link="PFS\PfsStructs.cs" />
+    <Compile Include="..\LibOrbisPkg\PKG\Entry.cs" Link="PKG\Entry.cs" />
+    <Compile Include="..\LibOrbisPkg\PKG\Enums.cs" Link="PKG\Enums.cs" />
+    <Compile Include="..\LibOrbisPkg\PKG\Pkg.cs" Link="PKG\Pkg.cs" />
+    <Compile Include="..\LibOrbisPkg\PKG\PkgBuilder.cs" Link="PKG\PkgBuilder.cs" />
+    <Compile Include="..\LibOrbisPkg\PKG\PkgProperties.cs" Link="PKG\PkgProperties.cs" />
+    <Compile Include="..\LibOrbisPkg\PKG\PkgReader.cs" Link="PKG\PkgReader.cs" />
+    <Compile Include="..\LibOrbisPkg\PKG\PkgWriter.cs" Link="PKG\PkgWriter.cs" />
+    <Compile Include="..\LibOrbisPkg\PlayGo\ChunkDat.cs" Link="PlayGo\ChunkDat.cs" />
+    <Compile Include="..\LibOrbisPkg\PlayGo\Manifest.cs" Link="PlayGo\Manifest.cs" />
+    <Compile Include="..\LibOrbisPkg\Rif\LicenseDat.cs" Link="Rif\LicenseDat.cs" />
+    <Compile Include="..\LibOrbisPkg\Rif\LicenseInfo.cs" Link="Rif\LicenseInfo.cs" />
+    <Compile Include="..\LibOrbisPkg\SFO\ParamSfo.cs" Link="SFO\ParamSfo.cs" />
+    <Compile Include="..\LibOrbisPkg\Util\Crypto.cs" Link="Util\Crypto.cs" />
+    <Compile Include="..\LibOrbisPkg\Util\Extensions.cs" Link="Util\Extensions.cs" />
+    <Compile Include="..\LibOrbisPkg\Util\Keys.cs" Link="Util\Keys.cs" />
+    <Compile Include="..\LibOrbisPkg\Util\MersenneTwister.cs" Link="Util\MersenneTwister.cs" />
+    <Compile Include="..\LibOrbisPkg\Util\OffsetStream.cs" Link="Util\OffsetStream.cs" />
+    <Compile Include="..\LibOrbisPkg\Util\ReaderBase.cs" Link="Util\ReaderBase.cs" />
+    <Compile Include="..\LibOrbisPkg\Util\StreamExtensions.cs" Link="Util\StreamExtensions.cs" />
+    <Compile Include="..\LibOrbisPkg\Util\SubStream.cs" Link="Util\SubStream.cs" />
+    <Compile Include="..\LibOrbisPkg\Util\WriterBase.cs" Link="Util\WriterBase.cs" />
+    <Compile Include="..\LibOrbisPkg\Util\XtsBlockTransform.cs" Link="Util\XtsBlockTransform.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="GP4\" />
+    <Folder Include="PlayGo\" />
+    <Folder Include="Util\" />
+    <Folder Include="Rif\" />
+    <Folder Include="SFO\" />
+    <Folder Include="PFS\" />
+    <Folder Include="PKG\" />
+  </ItemGroup>
+
+</Project>

--- a/LibOrbisPkg.sln
+++ b/LibOrbisPkg.sln
@@ -18,6 +18,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibArchiveExplorer", "GameA
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibOrbisPkgTests", "LibOrbisPkgTests\LibOrbisPkgTests.csproj", "{4BA1AA8A-A964-4E3D-9DDE-DC9F7749D3BE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibOrbisPkg.Core", "LibOrbisPkg.Core\LibOrbisPkg.Core.csproj", "{42CB09DF-61D0-4B0F-8462-10974FA356C7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +63,12 @@ Global
 		{4BA1AA8A-A964-4E3D-9DDE-DC9F7749D3BE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4BA1AA8A-A964-4E3D-9DDE-DC9F7749D3BE}.Release-minimal|Any CPU.ActiveCfg = Release|Any CPU
 		{4BA1AA8A-A964-4E3D-9DDE-DC9F7749D3BE}.Release-minimal|Any CPU.Build.0 = Release|Any CPU
+		{42CB09DF-61D0-4B0F-8462-10974FA356C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42CB09DF-61D0-4B0F-8462-10974FA356C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42CB09DF-61D0-4B0F-8462-10974FA356C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42CB09DF-61D0-4B0F-8462-10974FA356C7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42CB09DF-61D0-4B0F-8462-10974FA356C7}.Release-minimal|Any CPU.ActiveCfg = Release|Any CPU
+		{42CB09DF-61D0-4B0F-8462-10974FA356C7}.Release-minimal|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LibOrbisPkg.sln
+++ b/LibOrbisPkg.sln
@@ -18,7 +18,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibArchiveExplorer", "GameA
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibOrbisPkgTests", "LibOrbisPkgTests\LibOrbisPkgTests.csproj", "{4BA1AA8A-A964-4E3D-9DDE-DC9F7749D3BE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibOrbisPkg.Core", "LibOrbisPkg.Core\LibOrbisPkg.Core.csproj", "{42CB09DF-61D0-4B0F-8462-10974FA356C7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibOrbisPkg.Core", "LibOrbisPkg.Core\LibOrbisPkg.Core.csproj", "{42CB09DF-61D0-4B0F-8462-10974FA356C7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PkgTool.Core", "PkgTool.Core\PkgTool.Core.csproj", "{43EFDE22-CCE4-4D5C-9FAE-482BB2A613D8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -69,6 +71,12 @@ Global
 		{42CB09DF-61D0-4B0F-8462-10974FA356C7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{42CB09DF-61D0-4B0F-8462-10974FA356C7}.Release-minimal|Any CPU.ActiveCfg = Release|Any CPU
 		{42CB09DF-61D0-4B0F-8462-10974FA356C7}.Release-minimal|Any CPU.Build.0 = Release|Any CPU
+		{43EFDE22-CCE4-4D5C-9FAE-482BB2A613D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43EFDE22-CCE4-4D5C-9FAE-482BB2A613D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43EFDE22-CCE4-4D5C-9FAE-482BB2A613D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43EFDE22-CCE4-4D5C-9FAE-482BB2A613D8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43EFDE22-CCE4-4D5C-9FAE-482BB2A613D8}.Release-minimal|Any CPU.ActiveCfg = Release|Any CPU
+		{43EFDE22-CCE4-4D5C-9FAE-482BB2A613D8}.Release-minimal|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LibOrbisPkg/Util/Crypto.cs
+++ b/LibOrbisPkg/Util/Crypto.cs
@@ -193,7 +193,7 @@ namespace LibOrbisPkg.Util
       var tmp = new byte[size];
       using (var pt_stream = new MemoryStream(@in))
       using (var ct_stream = new MemoryStream(tmp))
-      using (var dec = cipher.CreateEncryptor())
+      using (var dec = cipher.CreateEncryptor(key, iv))
       using (var s = new CryptoStream(ct_stream, dec, CryptoStreamMode.Write))
       {
         pt_stream.CopyTo(s);
@@ -215,7 +215,7 @@ namespace LibOrbisPkg.Util
       var tmp = new byte[size];
       using (var ct_stream = new MemoryStream(@in))
       using (var pt_stream = new MemoryStream(tmp))
-      using (var dec = cipher.CreateDecryptor())
+      using (var dec = cipher.CreateDecryptor(key, iv))
       using (var s = new CryptoStream(ct_stream, dec, CryptoStreamMode.Read))
       {
         s.CopyTo(pt_stream);

--- a/LibOrbisPkg/Util/Extensions.cs
+++ b/LibOrbisPkg/Util/Extensions.cs
@@ -25,7 +25,7 @@ namespace LibOrbisPkg.Util
       return arr;
     }
   }
-
+#if !CORE
   public static class TupleExtension
   {
     public static void Deconstruct<T1,T2>(this Tuple<T1, T2> twople, out T1 item1, out T2 item2)
@@ -34,4 +34,5 @@ namespace LibOrbisPkg.Util
       item2 = twople.Item2;
     }
   }
+#endif
 }

--- a/PkgTool.Core/PkgTool.Core.csproj
+++ b/PkgTool.Core/PkgTool.Core.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <AssemblyName>PkgTool</AssemblyName>
+    <RootNamespace>PkgTool</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\PkgTool\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GameArchives\Library\GameArchives.csproj" />
+    <ProjectReference Include="..\LibOrbisPkg.Core\LibOrbisPkg.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/PkgTool/Program.cs
+++ b/PkgTool/Program.cs
@@ -15,15 +15,8 @@ namespace PkgTool
   {
     static void Main(string[] args)
     {
-      if(!Verb.Run(Verbs, args, "PkgTool.exe"))
+      if(!Verb.Run(Verbs, args, AppDomain.CurrentDomain.FriendlyName))
       {
-        Console.WriteLine("PkgTool.exe <verb> [options ...]");
-        Console.WriteLine("");
-        Console.WriteLine("Verbs:");
-        foreach (var verb in Verbs)
-        {
-          Console.WriteLine($"  {verb}");
-        }
         Console.WriteLine();
         Console.WriteLine("Use passcode \"fake\" to decrypt a FAKE PKG without knowing the actual passcode.");
       }
@@ -310,6 +303,13 @@ namespace PkgTool
           Console.WriteLine($"Usage: {name} {v}");
         }
         return true;
+      }
+      Console.WriteLine($"Usage: {name} <verb> [options ...]");
+      Console.WriteLine("");
+      Console.WriteLine("Verbs:");
+      foreach (var verb in verbs)
+      {
+        Console.WriteLine($"  {verb}");
       }
       return false;
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,5 +38,11 @@ after_build:
    %APPVEYOR_BUILD_FOLDER%\LibOrbisPkg\bin\Release\LibOrbisPkg.dll
    %APPVEYOR_BUILD_FOLDER%\README.md
    %APPVEYOR_BUILD_FOLDER%\LICENSE.txt
+ - >
+   7z a LibOrbisPkg-NetCore-%APPVEYOR_BUILD_VERSION%.zip 
+   %APPVEYOR_BUILD_FOLDER%\LibOrbisPkg.Core\bin\Release\netcoreapp2.2\LibOrbisPkg.Core.dll
+   %APPVEYOR_BUILD_FOLDER%\README.md
+   %APPVEYOR_BUILD_FOLDER%\LICENSE.txt
 artifacts:
 - path: LibOrbisPkg-%APPVEYOR_BUILD_VERSION%.zip
+- path: LibOrbisPkg-NetCore-%APPVEYOR_BUILD_VERSION%.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,8 @@ after_build:
  - >
    7z a LibOrbisPkg-NetCore-%APPVEYOR_BUILD_VERSION%.zip 
    %APPVEYOR_BUILD_FOLDER%\LibOrbisPkg.Core\bin\Release\netcoreapp2.2\LibOrbisPkg.Core.dll
+   %APPVEYOR_BUILD_FOLDER%\PkgTool.Core\bin\Release\netcoreapp2.2\PkgTool.dll
+   %APPVEYOR_BUILD_FOLDER%\PkgTool.Core\bin\Release\netcoreapp2.2\GameArchives.dll
    %APPVEYOR_BUILD_FOLDER%\README.md
    %APPVEYOR_BUILD_FOLDER%\LICENSE.txt
 artifacts:


### PR DESCRIPTION
.NET Core brings native support for Linux and macOS, in addition to things like the Span<T> and Memory<T> types which don't seem to be coming to .NET Framework any time soon...

Once .NET Core 3.0 lands with WinForms support, I'll update to that and port PkgEditor over.